### PR TITLE
Consume boolean tokens

### DIFF
--- a/sml-json.sml
+++ b/sml-json.sml
@@ -33,7 +33,12 @@ sig
    val error_handle  : string * int * string -> json_data
 end
 
-functor JSONParser (Callbacks : JSON_CALLBACKS) =
+functor JSONParser (Callbacks : JSON_CALLBACKS) :
+        sig
+            type json_data;
+            val parse        : string -> json_data;
+        end
+=
 struct
    type json_data = Callbacks.json_data
 


### PR DESCRIPTION
The current version of this errs out when it encounters a true or false token in the JSON. Fixed it by consuming the token before invoking the json_bool callback.

Also removed some trailing whitespace.
